### PR TITLE
ステップ５ 釣り銭と売り上げ管理

### DIFF
--- a/test/vending_machine_test.rb
+++ b/test/vending_machine_test.rb
@@ -125,4 +125,12 @@ class VendingMachineTest < Minitest::Test
 
     assert_equal ['水'], @vending_machine.buyable_drinks
   end
+
+  def test_ジュース値段以上の投入金額が投入されている条件下で購入操作を行うと、釣り銭（投入金額とジュース値段の差分）を出力する
+    @vending_machine.insert_money(100)
+    @vending_machine.insert_money(10)
+    @vending_machine.insert_money(10)
+
+    assert_equal 0, @vending_machine.sell('コーラ')
+  end
 end

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -44,6 +44,8 @@ class VendingMachine
       @stocks[drink_name][:count] -= 1
       @sales_amount += @stocks[drink_name][:price]
       @total_money_amount -= @stocks[drink_name][:price]
+
+      @total_money_amount
     end
   end
 


### PR DESCRIPTION
ジュース値段以上の投入金額が投入されている条件下で購入操作を行うと、釣り銭（投入金額とジュース値段の差分）を出力する。
- ジュースと投入金額が同じ場合、つまり、釣り銭0円の場合も、釣り銭0円と出力する。
- 釣り銭の硬貨の種類は考慮しなくてよい。