### PR TITLE
[WIP] ステップ6 釣り銭ストックの導入 ベースブランチ

### DIFF
--- a/test/vending_machine_test.rb
+++ b/test/vending_machine_test.rb
@@ -136,10 +136,9 @@ class VendingMachineTest < Minitest::Test
 
   def test_釣り銭ストックとして、有効なお札と硬貨10枚ずつを保持すること
     assert_equal 10, @vending_machine.change_stock['10']
-
-    #assert_equal 10, @vending_machine.change_stock['50']
-    #assert_equal 10, @vending_machine.change_stock['100']
-    #assert_equal 10, @vending_machine.change_stock['500']
-    #assert_equal 10, @vending_machine.change_stock['1_000']
+    assert_equal 10, @vending_machine.change_stock['50']
+    assert_equal 10, @vending_machine.change_stock['100']
+    assert_equal 10, @vending_machine.change_stock['500']
+    assert_equal 10, @vending_machine.change_stock['1000']
   end
 end

--- a/test/vending_machine_test.rb
+++ b/test/vending_machine_test.rb
@@ -133,4 +133,12 @@ class VendingMachineTest < Minitest::Test
 
     assert_equal 0, @vending_machine.sell('コーラ')
   end
+
+  def test_釣り銭ストックとして、有効なお札と硬貨10枚ずつを保持すること
+    assert_equal 10, @vending_machine.change_stock['10']
+    #assert_equal 10, @vending_machine.change_stock['50']
+    #assert_equal 10, @vending_machine.change_stock['100']
+    #assert_equal 10, @vending_machine.change_stock['500']
+    #assert_equal 10, @vending_machine.change_stock['1_000']
+  end
 end

--- a/test/vending_machine_test.rb
+++ b/test/vending_machine_test.rb
@@ -136,6 +136,7 @@ class VendingMachineTest < Minitest::Test
 
   def test_釣り銭ストックとして、有効なお札と硬貨10枚ずつを保持すること
     assert_equal 10, @vending_machine.change_stock['10']
+
     #assert_equal 10, @vending_machine.change_stock['50']
     #assert_equal 10, @vending_machine.change_stock['100']
     #assert_equal 10, @vending_machine.change_stock['500']

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -7,7 +7,7 @@ class VendingMachine
   # stocks: 現在の在庫
   # total_money_amount: 現在の投入金額合計
   # sales_amount: 売上金額合計
-  attr_reader :total_money_amount, :sales_amount
+  attr_reader :total_money_amount, :sales_amount, :change_stock
   attr_writer :stocks
 
   def initialize(stocks: {})
@@ -68,10 +68,6 @@ class VendingMachine
     @stocks.each_with_object([]) do |drink, memo|
       memo << drink[0] if drink[1][:price] <= @total_money_amount
     end
-  end
-
-  def change_stock
-    @change_stock
   end
 
   private

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -60,6 +60,10 @@ class VendingMachine
     end
   end
 
+  def change_stock
+    {'10' => 10}
+  end
+
   private
 
   def can_buy?(drink_name)

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -20,6 +20,7 @@ class VendingMachine
     # のようなハッシュでもってみる
     @stocks = stocks.dup
     @sales_amount = 0
+    @change_stock = {'10' => 10}
   end
 
   def stocks
@@ -61,7 +62,7 @@ class VendingMachine
   end
 
   def change_stock
-    {'10' => 10}
+    @change_stock
   end
 
   private

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -2,6 +2,7 @@ require "pry"
 
 class VendingMachine
   ACCEPTABLE_MONEY = [10, 50, 100, 500, 1_000].freeze
+  CHANGE_STOCK_COUNT = 10
 
   # stocks: 現在の在庫
   # total_money_amount: 現在の投入金額合計
@@ -20,7 +21,15 @@ class VendingMachine
     # のようなハッシュでもってみる
     @stocks = stocks.dup
     @sales_amount = 0
-    @change_stock = {'10' => 10}
+    # change_stock は、金種をキー、枚数を値として持つハッシュ。
+    # {
+    #   '10' => 10,
+    #   '50' => 10,
+    #   ...
+    # }
+    @change_stock = ACCEPTABLE_MONEY.each_with_object({}) do |money, memo|
+      memo[money.to_s] = CHANGE_STOCK_COUNT
+    end
   end
 
   def stocks


### PR DESCRIPTION
ステップ6をやる。
要件がわりと多いので、diff が見やすいよう複数の PR にわけてやりたい。

## #10 でやる
- 自動販売機は釣り銭ストックを持つ事ができる。
- 釣り銭ストックとして、有効な各お札と硬貨10枚ずつ保持する。
- 釣り銭用ストックを取得できる。

## #11 でやる

- 釣り銭を返す際は、値段の大きな物から硬貨を優先して出力するようにする。ストックからなくなった硬貨は、可能であれば他の硬貨で補う（例えば50円硬貨を10円硬貨で補う）
  - 釣り銭には投入金額のお札および硬貨も使える(110円入れて、100円の水を買うといった場合のように余分に入れたお金も戻る)。
  - 釣り銭を出力したら、釣り銭用ストックを減らす。
- 購入操作を行った際に、釣り銭用ストックが足りない場合、何もしない。
